### PR TITLE
Readme.md: Fix broken links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,10 +7,10 @@ Useful for netbooks with small screens.
 
 | With Maximus  | Without Maximus |
 |:-----:|:-----:|
-| ![Using Maximus](http://cdn.bitbucket.org/mathematicalcoffee/maximus-gnome-shell-extension/downloads/maximus.png) | ![Without Maximus (title bar shows)](http://cdn.bitbucket.org/mathematicalcoffee/maximus-gnome-shell-extension/downloads/no-maximus.png) |
+| [Using Maximus](maximus.png) | [Without Maximus (title bar shows)](no-maximus.png) |
 
 NOTE: with the titlebar of a window hidden, you may find it difficult to unmaximise/move a window.
-In this case, I recommend either remembering your system's keyboard shortcut for un/maximising a window (e.g. Alt+F10 on Fedora), or use the [Window Options GNOME shell extension](https://bitbucket.org/mathematicalcoffee/window-options-gnome-shell-extension) which adds a drop-down menu to the title bar in the top panel with these options (shameless plug, I wrote that one). You might also like the [Window Buttons extension](https://github.com/biox/Gnome-Shell-Window-Buttons-Extension) which adds the close, minimize, maximize buttons to the top panel.
+In this case, I recommend either remembering your system's keyboard shortcut for un/maximising a window (e.g. Alt+F10 on Fedora), or use the [Window Options GNOME shell extension](https://bitbucket.org/mathematicalcoffee/window-options-gnome-shell-extension) which adds a drop-down menu to the title bar in the top panel with these options (shameless plug, I wrote that one). You might also like the [Window Buttons extension](https://github.com/danielkza/Gnome-Shell-Window-Buttons-Extension) which adds the close, minimize, maximize buttons to the top panel.
 
 ### Known issues
 


### PR DESCRIPTION
A couple of image links were trying to link to something on bitbucket that cannot be found.  Changed these absolute web links to relative github links to the two pictures in this repo.  Also updated the link to the "Gnome-Shell-Window-Buttons-Extension" repo - which has since changed maintainers.
